### PR TITLE
Changed Party Member Hover Details

### DIFF
--- a/website/client/components/memberDetails.vue
+++ b/website/client/components/memberDetails.vue
@@ -41,6 +41,7 @@
   @import '~client/assets/scss/colors.scss';
 
   .member-details {
+	margin-left: 20px;
     white-space: nowrap;
     transition: all 0.15s ease-out;
   }
@@ -144,7 +145,7 @@
     .member-stats {
       background: $header-dark-background;
       position: absolute;
-      right: 100%;
+      left: 100%;
       height: calc(100% + 18px);
       margin-top: -9px;
       padding-top: 9px;


### PR DESCRIPTION
[//]: # (Note: See http://habitica.wikia.com/wiki/Using_Your_Local_Install_to_Modify_Habitica%27s_Website_and_API for more info)

[//]: # (Put Issue # or URL here, if applicable. This will automatically close the issue if your PR is merged in)
Fixes put_issue_url_here

### Changes
[//]: # (Describe the changes that were made in detail here. Include pictures if necessary)
Before the change: when in a party, hovering over another party member shows their stats as a popup to the left, covering the Players. After the change, the popup is to the right, covering other party members and leaving the static players stats uncovered.
